### PR TITLE
Seiya pc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ uvicorn server_api:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 Expo Goのインストールごとに付与されるユニークなIDでユーザ識別を行う（IDの取得はクライエントが担う。サーバは受け取るだけ）。
-各ユーザには以下の情報が紐づけられる。これらの情報は`user.json`に保存される。
+各ユーザには以下の情報が紐づけられる。これらの情報は`users.json`に保存される。
 ```json
   "user-123456789abc": {
     "preferences": { "emotion": "明るい", "custom": "政治の話はやだ" },
@@ -54,5 +54,21 @@ Expo Goのインストールごとに付与されるユニークなIDでユー�
   },
 ```
 
-各ユーザが送信、受信してきた手紙はユニークな手紙IDで管理する。手紙本体は`.txt`形式で`letter_contents`で保存される。
+各ユーザが送信、受信してきた手紙はユニークな手紙IDで管理する。手紙本体は`letters.json`に保存される。
+```json
+    "letter-9c7ddee1-de49-49eb-847d-761b4ddf6224": {
+        "id": "letter-9c7ddee1-de49-49eb-847d-761b4ddf6224",
+        "title": "タイトル",
+        "sender_id": "user-fb5f58dbe91e",
+        "recipient_id": [
+            "waiting" // userId, "waiting", "rejected"のいずれか
+        ],
+        "date_sent": "2025-06-03 00:00:00Z",
+        "content": "メールの本文はここ"
+    },
+```
 
+## サーバの動作
+クライエント側はアプリ起動時にサーバに自分のIDが登録されているかどうかの確認を行い、サーバはそれに対して返事を行う。
+
+手紙が届くたびに、まず手紙に一意なUUIDを付与して`letters.json`に登録し、受信者の指定を試みる。送信者がサーバのデータベース（`users.json`）に登録されていない場合に登録する。

--- a/data/letters.json
+++ b/data/letters.json
@@ -8,35 +8,5 @@
         ],
         "date_sent": "2025-06-03 01:59:45Z",
         "content": "こんな感じに"
-    },
-    "letter-a3212248-3c08-4068-a881-6950f1a7be25": {
-        "id": "letter-a3212248-3c08-4068-a881-6950f1a7be25",
-        "title": "タイトル",
-        "sender_id": "user-fb5f58dbe91e",
-        "recipient_id": [
-            "waiting"
-        ],
-        "date_sent": "2025-06-03 02:00:30Z",
-        "content": "こんな感じに"
-    },
-    "letter-e67840c3-95c1-4a9b-b327-6c2e86349886": {
-        "id": "letter-e67840c3-95c1-4a9b-b327-6c2e86349886",
-        "title": "こ",
-        "sender_id": "user-fb5f58dbe91e",
-        "recipient_id": [
-            "waiting"
-        ],
-        "date_sent": "2025-06-03 02:14:54Z",
-        "content": "ここ"
-    },
-    "letter-f6a95904-2c27-4e3c-be8c-f26555286c4a": {
-        "id": "letter-f6a95904-2c27-4e3c-be8c-f26555286c4a",
-        "title": "こ",
-        "sender_id": "user-fb5f58dbe91e",
-        "recipient_id": [
-            "waiting"
-        ],
-        "date_sent": "2025-06-03 02:17:01Z",
-        "content": "ここ"
     }
 }


### PR DESCRIPTION
README.mdをご確認ください。
サーバーにユーザと手紙を管理するためのファイルを作成。
新しいユーザがサーバに手紙を送信するとき、未登録のユーザなら自動でサーバのデータに登録。
手紙はUUIDで管理する。送信機能はこれから確認する。